### PR TITLE
Fix run result polling loop

### DIFF
--- a/routes/article_summary/ArticleSummarizer.py
+++ b/routes/article_summary/ArticleSummarizer.py
@@ -190,4 +190,5 @@ def getRunResult(run_res):
             run_id = run_res.id
         )
         status = run.status
+        attempts += 1
     return run


### PR DESCRIPTION
## Summary
- fix infinite loop in `getRunResult`

## Testing
- `python -m py_compile routes/article_summary/ArticleSummarizer.py`

------
https://chatgpt.com/codex/tasks/task_e_683f8ea66570833187dc817784294839