### PR TITLE
Add BackgroundGenerator route

### DIFF
--- a/function_app.py
+++ b/function_app.py
@@ -5,6 +5,7 @@ import azure.functions as func
 from openai import OpenAI
 import os
 from routes.article_summary.ArticleSummarizer import ArticleSummarizer
+from routes.background_generator.BackgroundGenerator import BackgroundGenerator as BackgroundGeneratorFunc
 import json
 
 app = func.FunctionApp(http_auth_level=func.AuthLevel.FUNCTION)
@@ -13,3 +14,8 @@ client = OpenAI(api_key=os.getenv("OPENAI_API_KEY"))
 @app.route(route="ArticleSummary")
 def ArticleSummary(req: func.HttpRequest) -> func.HttpResponse:
     return ArticleSummarizer(req)
+
+
+@app.route(route="BackgroundGenerator")
+def BackgroundGenerator(req: func.HttpRequest) -> func.HttpResponse:
+    return BackgroundGeneratorFunc(req)

--- a/routes/background_generator/BackgroundGenerator.py
+++ b/routes/background_generator/BackgroundGenerator.py
@@ -1,0 +1,49 @@
+import azure.functions as func
+import json
+import os
+import logging
+from openai import OpenAI
+
+CLIENT = OpenAI(api_key=os.getenv("OPENAI_API_KEY"))
+
+
+def BackgroundGenerator(req: func.HttpRequest) -> func.HttpResponse:
+    try:
+        body = req.get_json()
+    except Exception:
+        body = None
+
+    content = None
+    if body and isinstance(body, dict):
+        content = body.get("content")
+    if not content:
+        content = req.params.get("content")
+
+    if not content:
+        return func.HttpResponse(
+            body=json.dumps({"message": "No content provided"}),
+            status_code=400,
+            mimetype="application/json",
+        )
+
+    try:
+        response = CLIENT.images.generate(
+            model="dall-e-3",
+            prompt=content,
+            size="1024x1024",
+            quality="standard",
+            n=1,
+        )
+        image_url = response.data[0].url
+        return func.HttpResponse(
+            body=json.dumps({"url": image_url}),
+            status_code=200,
+            mimetype="application/json",
+        )
+    except Exception as e:
+        logging.exception("Failed to generate image")
+        return func.HttpResponse(
+            body=json.dumps({"message": "Failed to generate image"}),
+            status_code=500,
+            mimetype="application/json",
+        )


### PR DESCRIPTION
## Summary
- create BackgroundGenerator route that calls DALL-E image generation
- expose the route from Azure function app

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683f9214f010833190a02dbce316f120